### PR TITLE
[COD-1372] Move toolbar for logical tab order, add test props

### DIFF
--- a/examples/cats/app.js
+++ b/examples/cats/app.js
@@ -177,6 +177,7 @@ class App extends Component {
               padding: '1.833rem',
             },
             fill: '#0D74AF',
+            tabIndex: 0,
           }}
           thumbnailImages={thumbs}
           imageHeaderComponent={ImageHeader}

--- a/examples/cats/stylesheets/app.css
+++ b/examples/cats/stylesheets/app.css
@@ -34,3 +34,7 @@
 .demoButton:focus {
   box-shadow: 0 0 3px 2px #999;
 }
+
+.closeButton:focus {
+  outline: #0d74af solid 1px;
+}

--- a/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
+++ b/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
@@ -176,7 +176,6 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                     </div>
                   </div>
                 </div>
-                 
                 <div
                   class="ril__toolbar"
                 >
@@ -203,6 +202,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                   </div>
                    
                 </div>
+                 
                 <div
                   class="ril__thumbNailsContainer"
                 >
@@ -420,7 +420,6 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                   </div>
                 </div>
               </div>
-               
               <div
                 className="ril__toolbar"
               >
@@ -450,6 +449,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
                 </div>
                  
               </div>
+               
               <div
                 className="ril__thumbNailsContainer"
               >

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1506,6 +1506,49 @@ class ReactImageLightbox extends Component {
           >
             {images}
           </div>
+          {/* Lightbox toolbar */}
+          <div className="ril__toolbar">
+            {this.props.imageHeaderComponent ? (
+              <this.props.imageHeaderComponent
+                imageTitle={imageTitle}
+                imageIndex={imageIndex}
+                totalImageCount={images.length + 1}
+              />
+            ) : (
+              <div className="ril_title">
+                {imageTitle}
+                <div className="ril_status">
+                  Image {imageIndex} of {images.length + 1}
+                </div>
+              </div>
+            )}
+            <div className="ril__toolbarItem">
+              {this.props.closeButtonComponent ? (
+                <this.props.closeButtonComponent
+                  close={!this.isAnimating() ? this.requestClose : undefined}
+                  {...this.props.closeButtonComponentProps}
+                />
+              ) : (
+                <button // Lightbox close button
+                  type="button"
+                  key="close"
+                  aria-label={this.props.closeLabel}
+                  title={this.props.closeLabel}
+                  className={`ril__toolbarItemChild ril__builtinButton ${
+                    this.props.closeButtonImage ? '' : 'ril__closeButton'
+                  }`}
+                  onClick={!this.isAnimating() ? this.requestClose : undefined} // Ignore clicks during animation
+                  style={
+                    this.props.closeButtonImage
+                      ? {
+                          background: `url('${this.props.closeButtonImage}') no-repeat center`,
+                        }
+                      : {}
+                  }
+                />
+              )}
+            </div>{' '}
+          </div>
           {prevSrc && !isMobile ? (
             <button // Move to previous image button
               type="button"
@@ -1551,49 +1594,6 @@ class ReactImageLightbox extends Component {
             ) : (
               ''
             ))}
-          {/* Lightbox toolbar */}
-          <div className="ril__toolbar">
-            {this.props.imageHeaderComponent ? (
-              <this.props.imageHeaderComponent
-                imageTitle={imageTitle}
-                imageIndex={imageIndex}
-                totalImageCount={images.length + 1}
-              />
-            ) : (
-              <div className="ril_title">
-                {imageTitle}
-                <div className="ril_status">
-                  Image {imageIndex} of {images.length + 1}
-                </div>
-              </div>
-            )}
-            <div className="ril__toolbarItem">
-              {this.props.closeButtonComponent ? (
-                <this.props.closeButtonComponent
-                  close={!this.isAnimating() ? this.requestClose : undefined}
-                  {...this.props.closeButtonComponentProps}
-                />
-              ) : (
-                <button // Lightbox close button
-                  type="button"
-                  key="close"
-                  aria-label={this.props.closeLabel}
-                  title={this.props.closeLabel}
-                  className={`ril__toolbarItemChild ril__builtinButton ${
-                    this.props.closeButtonImage ? '' : 'ril__closeButton'
-                  }`}
-                  onClick={!this.isAnimating() ? this.requestClose : undefined} // Ignore clicks during animation
-                  style={
-                    this.props.closeButtonImage
-                      ? {
-                          background: `url('${this.props.closeButtonImage}') no-repeat center`,
-                        }
-                      : {}
-                  }
-                />
-              )}
-            </div>{' '}
-          </div>
           {!isMobile && (
             <div className="ril__thumbNailsContainer">
               <div className="ril__thumbNails">


### PR DESCRIPTION
Moves toolbar to be the first element, ensures the close button can be tabbed first. Also adds focus style, `tabindex` props to test component.

Ticket: [COD-1372](https://kunaiconsulting.atlassian.net/browse/COD-1372)