### PR TITLE
ci: Publish alpha versions with alpha tag

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -28,6 +28,11 @@ jobs:
           node-version: 14
           registry-url: https://npm.pkg.github.com/
       - run: yarn
-      - run: npm publish
+      - run: |
+          if [[ $(npx -c 'echo $npm_package_version') == *alpha* ]]; then
+            npm publish --tag alpha
+          else
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
We need to publish alpha versions with an alpha tag so that it is not automatically installed if the package version isn't pinned to a specific version in the package.json file of consuming projects. By default, if we do not specify a tag, it will be tagged as `latest` which would allow any consumer to inadvertently install it.

See https://docs.npmjs.com/adding-dist-tags-to-packages